### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ braillegraph (0.3-3) UNRELEASED; urgency=medium
     Repository-Browse.
   * Use canonical URL in Vcs-Git.
   * Update standards version to 4.6.1, no changes needed.
+  * Update standards version to 4.6.2, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 13:04:56 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ braillegraph (0.3-3) UNRELEASED; urgency=medium
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Update standards version to 4.6.1, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 13:04:56 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ braillegraph (0.3-3) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 11 Sep 2021 13:04:56 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper-compat (= 13)
 Standards-Version: 4.6.0
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/braillegraph
-Vcs-Git: https://github.com/kilobyte/braillegraph -b debian
+Vcs-Git: https://github.com/kilobyte/braillegraph.git -b debian
 Vcs-Browser: https://github.com/kilobyte/braillegraph/commits/master
 
 Package: braillegraph

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: math
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/braillegraph
 Vcs-Git: https://github.com/kilobyte/braillegraph.git -b debian

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: math
 Priority: optional
 Maintainer: Adam Borowski <kilobyte@angband.pl>
 Build-Depends: debhelper-compat (= 13)
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Rules-Requires-Root: no
 Homepage: https://github.com/kilobyte/braillegraph
 Vcs-Git: https://github.com/kilobyte/braillegraph.git -b debian


### PR DESCRIPTION
Fix some issues reported by lintian

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))
* Update standards version to 4.6.1, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))
* Update standards version to 4.6.2, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version))

These changes have no impact on the [binary debdiff](https://janitor.debian.net/api/run/851e01ee-267f-40fd-ada8-445c7dcc9b8f/debdiff?filter_boring=1).

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/851e01ee-267f-40fd-ada8-445c7dcc9b8f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/851e01ee-267f-40fd-ada8-445c7dcc9b8f/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/lintian-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/851e01ee-267f-40fd-ada8-445c7dcc9b8f.